### PR TITLE
Add new character size between Medium & Big

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -930,7 +930,7 @@ var/list/preferences_datums = list()
 							special_color[text2num(index_tc)]=null
 
 				if("character_size")
-					var/new_size = input(user, "Choose your character's size:", "Character Preference")  in list("big", "normal", "small", "tiny")
+					var/new_size = input(user, "Choose your character's size:", "Character Preference")  in list("huge", "large", "normal", "small", "tiny")
 					if(new_size)
 						character_size=new_size
 
@@ -1201,8 +1201,10 @@ var/list/preferences_datums = list()
 			character.sizeplay_set(SIZEPLAY_MICRO)
 		else if(character_size=="tiny")
 			character.sizeplay_set(SIZEPLAY_TINY)
-		else
+		else if(character_size=="large")
 			character.sizeplay_set(SIZEPLAY_MACRO)
+		else
+			character.sizeplay_set(SIZEPLAY_HUGE)
 
 	character.eye_color = eye_color
 	character.hair_color = hair_color

--- a/code/narky/macro.dm
+++ b/code/narky/macro.dm
@@ -2,6 +2,7 @@ var/const/SIZEPLAY_TINY=1
 var/const/SIZEPLAY_MICRO=2
 var/const/SIZEPLAY_NORMAL=3
 var/const/SIZEPLAY_MACRO=4
+var/const/SIZEPLAY_HUGE=5
 
 /mob/living
 	var/sizeplay_size=SIZEPLAY_NORMAL
@@ -20,7 +21,7 @@ var/const/SIZEPLAY_MACRO=4
 				else if(newsize>initial(src.sizeplay_size))
 					//src.transform=get_matrix_large()
 					//src.pixel_y=16
-					stable_matrix(get_matrix_large(),16)
+					stable_matrix(get_matrix_large(),8)
 					src.sizeplay_size=newsize
 					return
 				return //Paranoid returns
@@ -38,7 +39,12 @@ var/const/SIZEPLAY_MACRO=4
 			else if(newsize==SIZEPLAY_MACRO)
 				//src.transform=get_matrix_large()
 				//src.pixel_y=16
-				stable_matrix(get_matrix_large(),16)
+				stable_matrix(get_matrix_large(),8)
+				src.sizeplay_size=newsize
+			else if(newsize==SIZEPLAY_HUGE) // Huge should be the largest size
+				// removed these comments
+				// not being used anyway
+				stable_matrix(get_matrix_largest(),16)
 				src.sizeplay_size=newsize
 			else
 				//src.transform=get_matrix_norm()
@@ -56,7 +62,7 @@ var/const/SIZEPLAY_MACRO=4
 		sizeplay_grow()
 			//if(!istype(src,/mob/living/carbon))
 			//	return
-			if(sizeplay_size<SIZEPLAY_MACRO)
+			if(sizeplay_size<SIZEPLAY_HUGE)
 				src.sizeplay_set(sizeplay_size+1)
 				for(var/mob/living/M in src.stomach_contents)
 					M.sizeplay_grow()
@@ -77,9 +83,12 @@ var/const/SIZEPLAY_MACRO=4
 //var/matrix/transform_small=new().Scale(0.5)
 //var/matrix/transform_norm=new()
 //var/matrix/transform_large=new().Scale(2)
-/proc/get_matrix_large()
+/proc/get_matrix_largest()
 	var/matrix/mtrx=new()
 	return mtrx.Scale(2)
+/proc/get_matrix_large()
+	var/matrix/mtrx=new()
+	return mtrx.Scale(1.5)
 /proc/get_matrix_norm()
 	var/matrix/mtrx=new()
 	return mtrx


### PR DESCRIPTION
Adds a new size in-between the "normal" and "big" sizes of the old version, meaning there's now 2 size steps up & down from "normal height". Also renames the previous "big" to "huge" and the new in-between to "large". All size-changing effects work, and "Huge" is now effectively the largest size & can insuit people Normal or below.

Code changes:
macro.dm
Added sizeplay_size_huge, with a scale of 2.
Changed sizeplay_size_macro to have a scale of 1.5 instead of 2.
Made sizeplay_size_huge the largest size possible.

preferences.dm
Removed "big" as a character creation option.
Replaced it with "large" for 1.5x macro scale, and "huge" for the old 2x macro scale.
Old "big" characters should enter the round as "huge" by default, but players of big characters should reset their size settings anyway to choose Large or Huge.