### PR TITLE
Fixing a MASSIVELY game breaking bug.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -315,7 +315,11 @@
 	flick(icon_state, src)
 	sleep(animation_length+1)
 	notransform = 0
-	if(icon_state == "k9" || "medihound") //use for wide sprites
+	if(icon_state == "k9") //use for wide sprites
+		icon = 'icons/mob/widerobot.dmi'
+		pixel_x = -16
+		return
+	if(icon_state == "medihound") //use for wide sprites
 		icon = 'icons/mob/widerobot.dmi'
 		pixel_x = -16
 		return


### PR DESCRIPTION
For some reason, at least on one round, the borg transform code would refuse to use the right sprite file for 32p wide ones.