### PR TITLE
panic bunker for moderators

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -61,7 +61,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/cmd_admin_local_narrate,	/*sends text to all mobs within view of atom*/
 	/client/proc/cmd_admin_create_centcom_report,
 	/client/proc/toggle_antag_hud,		/*toggle display of the admin antag hud*/
-	/client/proc/doorfix				/* door fixings */
+	/client/proc/doorfix,				/* door fixings */
+	/client/proc/panicbunker
 	)
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -113,7 +114,6 @@ var/list/admin_verbs_server = list(
 	/client/proc/forcerandomrotate,
 	/client/proc/adminchangemap,
 #endif
-	/client/proc/panicbunker
 
 	)
 var/list/admin_verbs_debug = list(

--- a/code/modules/admin/verbs/panicbunker.dm
+++ b/code/modules/admin/verbs/panicbunker.dm
@@ -1,5 +1,5 @@
 /client/proc/panicbunker()
-	set category = "Server"
+	set category = "Admin"
 	set name = "Toggle Panic Bunker"
 	if (!config.sql_enabled)
 		usr << "<span class='adminnotice'>The Database is not enabled!</span>"


### PR DESCRIPTION
Should enable moderators (who have +ADMIN) to use panic bunker

bunker button was moved from server to admin