### PR TITLE
sleep pen change/mode tweaks

### DIFF
--- a/code/game/gamemodes/abduction/abduction.dm
+++ b/code/game/gamemodes/abduction/abduction.dm
@@ -8,7 +8,7 @@
 	config_tag = "abduction"
 	antag_flag = ROLE_ABDUCTOR
 	recommended_enemies = 2
-	required_players = 15
+	required_players = 5
 	var/max_teams = 4
 	abductor_teams = 1
 	var/list/datum/mind/scientists = list()

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -18,7 +18,7 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	antag_flag = ROLE_CHANGELING
 	restricted_jobs = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
-	required_players = 15
+	required_players = 5
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -54,7 +54,7 @@
 	antag_flag = ROLE_CULTIST
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
 	protected_jobs = list()
-	required_players = 20
+	required_players = 10
 	required_enemies = 4
 	recommended_enemies = 4
 	enemy_minimum_age = 14

--- a/code/game/gamemodes/handofgod/_handofgod.dm
+++ b/code/game/gamemodes/handofgod/_handofgod.dm
@@ -24,7 +24,7 @@ var/global/list/global_handofgod_structuretypes = list()
 	config_tag = "handofgod"
 	antag_flag = ROLE_HOG_CULTIST		//Followers use ROLE_HOG_CULTIST, Gods are picked later on with ROLE_HOG_GOD
 
-	required_players = 25
+	required_players = 10
 	required_enemies = 8
 	recommended_enemies = 8
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -5,7 +5,7 @@
 	name = "AI malfunction"
 	config_tag = "malfunction"
 	antag_flag = ROLE_MALF
-	required_players = 25
+	required_players = 10
 	required_enemies = 1
 	recommended_enemies = 1
 	enemy_minimum_age = 30 //Same as AI minimum age

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -5,8 +5,8 @@
 /datum/game_mode/nuclear
 	name = "nuclear emergency"
 	config_tag = "nuclear"
-	required_players = 20 // 20 players - 5 players to be the nuke ops = 15 players remaining
-	required_enemies = 5
+	required_players = 10 // 20 players - 5 players to be the nuke ops = 15 players remaining
+	required_enemies = 2
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE
 	enemy_minimum_age = 14

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -15,7 +15,7 @@
 	config_tag = "revolution"
 	antag_flag = ROLE_REV
 	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer")
-	required_players = 20
+	required_players = 10
 	required_enemies = 1
 	recommended_enemies = 3
 	enemy_minimum_age = 14

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -68,8 +68,8 @@ Made by Xhuis
 	name = "shadowling"
 	config_tag = "shadowling"
 	antag_flag = ROLE_SHADOWLING
-	required_players = 30
-	required_enemies = 2
+	required_players = 10
+	required_enemies = 1
 	recommended_enemies = 2
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -5,7 +5,7 @@
 	name = "wizard"
 	config_tag = "wizard"
 	antag_flag = ROLE_WIZARD
-	required_players = 20
+	required_players = 10
 	required_enemies = 1
 	recommended_enemies = 1
 	enemy_minimum_age = 14

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -66,7 +66,7 @@
  */
 /obj/item/weapon/pen/sleepy
 	origin_tech = "materials=2;syndicate=5"
-	flags = OPENCONTAINER
+	//flags = OPENCONTAINER
 
 
 /obj/item/weapon/pen/sleepy/attack(mob/living/M, mob/user)


### PR DESCRIPTION
game mode tweaks to allow chances of others to be selected even during low pop. number of antags also lowered to balance this.

sleepy pen no longer shows itself as a container when examined.